### PR TITLE
Fix auth endpoints

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::BTreeMap};
 use thiserror::Error;
 
 #[derive(Serialize, Default, Deserialize, Clone, Debug)]
-pub struct Empty;
+pub struct Empty {}
 
 /// ----------------------------------------
 ///  RESPONSE STRUCTS FOR MARKET REQUESTS

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,8 +5,8 @@ use serde_json::{from_value, Value};
 use std::{borrow::Cow, collections::BTreeMap};
 use thiserror::Error;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Empty {}
+#[derive(Serialize, Default, Deserialize, Clone, Debug)]
+pub struct Empty;
 
 /// ----------------------------------------
 ///  RESPONSE STRUCTS FOR MARKET REQUESTS
@@ -3101,8 +3101,10 @@ pub struct AccountInfoResponse {
     pub ret_code: i32,
     pub ret_msg: String,
     pub result: AccountInfo,
+    #[serde(default)]
     pub ret_ext_info: Empty,
-    pub time: u64,
+    #[serde(default)]
+    pub time: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,12 @@ pub fn build_request<T: ToString>(parameters: &BTreeMap<String, T>) -> String {
     for (key, value) in parameters {
         request.push_str(key);
         request.push('=');
-        request.push_str(&value.to_string());
+        let mut value = value.to_string();
+        if value.starts_with("\"") && value.ends_with("\"") {
+            // trim leading and trailing `"`
+            value = value[1..value.len() - 1].to_string();
+        }
+        request.push_str(&value);
         request.push('&');
     }
     request.truncate(request.len() - 1);


### PR DESCRIPTION
One major bug fix: fix endpoints requiring auth failing with 'error sign!' because `accountType="UNIFIED"` was used instead of expected  `accountType=UNIFIED` (no quotes).
One minor bug fix: fix get account info which failed because Bybit JSON response did not contain `time` nor `ret_ext_info` (`"retExtInfo"`) - made them optional.