### PR TITLE
enable non static str values for API Key and Secret thanks to Cow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "rs_bybit"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "futures",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub rest_api_endpoint: &'static str,
-    pub ws_endpoint: &'static str,
+    pub rest_api_endpoint: Cow<'static, str>,
+    pub ws_endpoint: Cow<'static, str>,
     pub recv_window: u16,
 }
 
@@ -9,23 +11,35 @@ impl Config {
     pub const DEFAULT_REST_API_ENDPOINT: &'static str = "https://api.bybit.com";
     pub const DEFAULT_WS_ENDPOINT: &'static str = "wss://stream.bybit.com/v5";
 
+    pub fn new(
+        rest_api_endpoint: impl AsRef<str>,
+        ws_endpoint: impl AsRef<str>,
+        recv_window: impl Into<u16>,
+    ) -> Self {
+        Self {
+            rest_api_endpoint: Cow::Owned(rest_api_endpoint.as_ref().to_string()),
+            ws_endpoint: Cow::Owned(ws_endpoint.as_ref().to_string()),
+            recv_window: recv_window.into(),
+        }
+    }
+
     pub const fn default() -> Self {
         Self {
-            rest_api_endpoint: Self::DEFAULT_REST_API_ENDPOINT,
-            ws_endpoint: Self::DEFAULT_WS_ENDPOINT,
+            rest_api_endpoint: Cow::Borrowed(Self::DEFAULT_REST_API_ENDPOINT),
+            ws_endpoint: Cow::Borrowed(Self::DEFAULT_WS_ENDPOINT),
             recv_window: 5000,
         }
     }
 
     pub const fn testnet() -> Self {
         Self {
-            rest_api_endpoint: "https://api-testnet.bybit.com",
-            ws_endpoint: "wss://stream-testnet.bybit.com/v5",
+            rest_api_endpoint: Cow::Borrowed("https://api-testnet.bybit.com"),
+            ws_endpoint: Cow::Borrowed("wss://stream-testnet.bybit.com/v5"),
             recv_window: 5000,
         }
     }
 
-    pub const fn set_recv_window(self, recv_window: u16) -> Self {
+    pub fn set_recv_window(self, recv_window: u16) -> Self {
         Self {
             recv_window,
             ..self


### PR DESCRIPTION
Adding a new, non const, pub ctor of `Config` called `new` which accepts str and String - without requirement of them to be &'static str. 